### PR TITLE
test: add write command tc

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -1,5 +1,5 @@
 class Shell:
-    def init(self, ssd=None):
+    def __init__(self, ssd=None):
         self._ssd = ssd
 
     def run(self):
@@ -18,8 +18,7 @@ class Shell:
                         lba = int(parts[1])
                         data = parts[2]
                         print(f'[Write] LBA: {lba}, Data: {data}')
-                        ## Write 동작
-                        ## --------
+                        self._ssd.write(lba, data)
                         print('[Write] Done')
                     except ValueError:
                         print('[Write] ERROR')
@@ -31,8 +30,7 @@ class Shell:
                     try:
                         lba = int(parts[1])
                         print(f'[Read] LBA: {lba}')
-                        ## Read 동작
-                        ## --------
+                        self._ssd.read(lba)
                         print('[Read] Done')
                     except ValueError:
                         print('[Read] ERROR')

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -1,0 +1,13 @@
+from pytest_mock import MockerFixture
+
+from shell import Shell
+
+
+def test_shell_write_cmd_has_called(mocker: MockerFixture):
+    ssd = mocker.Mock()
+    mocker.patch('builtins.input', side_effect=['write 3 0xEEEEFFFF', 'exit'])
+    shell = Shell(ssd)
+
+    shell.run()
+
+    ssd.write.assert_called_once()


### PR DESCRIPTION
## 🏷️ PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring

## 📌 Related Issue
- Shell Command 중 'Write' 호출 테스트
- TDD형식으로 TC 작성 이후 Shell class 구현 완료(Green 단계)

## 🚀 Description
- SSD객체를 mock으로 Shell 객체 생성시 주입했습니다.
- Shell의 input으로 'write' 가 입력되도록 patch를 사용했습니다.
- Shell의 무한루프를 종료하기 위해 이어서 'exit'명령어도 실행했습니다.
- Shell에 Write명령을 내렸을 때, 내부 ssd객체의 Write함수를 잘 호출하는지, assert_called_once()를 통해 체크했습니다.
- TC를 기반으로 Shell class 코드를 구현 완료했습니다.

## 📢 Notes (전달사항, Test 여부)
- 현재 Shell 폴더 경로의 모든 Test 통과했습니다.
<img width="398" height="303" alt="image" src="https://github.com/user-attachments/assets/9d0a560b-4663-4759-bb31-f7df7021bed4" />



### [Ground Rule](https://github.com/hobism3/SSD_A-Teuk/issues/20)
### [Code Review 전략](https://github.com/hobism3/SSD_A-Teuk/issues/1)
