### PR TITLE
Add unit tests for help, read, and write shell commands

### DIFF
--- a/tests/shell/test_help.py
+++ b/tests/shell/test_help.py
@@ -1,30 +1,26 @@
+from typing import Any, Callable
+
 import pytest
 from pytest import CaptureFixture
 from pytest_mock import MockFixture
 
+LBA_RANGE = range(100)
+HELP_MESSAGE = """Documented commands (type help <topic>):
+  write\tWrite data to an LBA
+  read\tRead data from an LBA
+  fullwrite\tWrite data to all LBAs
+  fullread\tRead data from all LBAs
+  help\tShow help for commands"""
 
-def help_message(*args, **kwargs):
-    print('Documented commands (type help <topic>):')
-    print('  write\tWrite data to an LBA')
-    print('  read\tRead data from an LBA')
-    print('  fullwrite\tWrite data to all LBAs')
-    print('  fullread\tRead data from all LBAs')
-    print('  help\tShow help for commands')
+READ_HELP_MESSAGE = 'Invalid arguments. Usage: read <lba>'
+WRITE_HELP_MESSAGE = 'Invalid arguments. Usage: write <lba> <hex data>'
+MEMORY_MAP = {0: 0x00AABBCC, 1: 0x12345678, 99: 0x9ABCDEF0}
+
+CommandHandler = Callable[[str], Any]
 
 
-def test_help_default(capsys: CaptureFixture, mocker: MockFixture) -> None:
-    mock_shell = mocker.Mock()
-    mock_shell.cmd.side_effect = lambda cmd: help_message() if cmd == 'help' else None
-    mock_shell.cmd('help')
-    captured = capsys.readouterr()
-    output = captured.out
-
-    assert 'Documented commands (type help <topic>):' in output
-    assert 'write' in output
-    assert 'read' in output
-    assert 'fullwrite' in output
-    assert 'fullread' in output
-    assert 'help' in output
+def help_message(*args, **kwargs) -> None:
+    print(HELP_MESSAGE)
 
 
 def parse_read_command(cmd: str) -> str:
@@ -33,9 +29,9 @@ def parse_read_command(cmd: str) -> str:
         len(parts) != 2
         or parts[0] != 'read'
         or not parts[1].isdigit()
-        or not -1 < int(parts[1]) < 100
+        or int(parts[1]) not in LBA_RANGE
     ):
-        raise ValueError('Invalid arguments. Usage: read <lba>')
+        raise ValueError(READ_HELP_MESSAGE)
     return parts[1]
 
 
@@ -45,82 +41,78 @@ def parse_write_command(cmd: str) -> tuple[str, str]:
         len(parts) != 3
         or parts[0] != 'write'
         or not parts[1].isdigit()
-        or not -1 < int(parts[1]) < 100
+        or int(parts[1]) not in LBA_RANGE
         or not (parts[2].startswith('0x') or parts[2].isdigit())
     ):
-        raise ValueError('Invalid arguments. Usage: write <lba> <hex data>')
+        raise ValueError(WRITE_HELP_MESSAGE)
     return parts[1], parts[2]
 
 
-def test_read_command_returns_expected_values_for_valid_inputs(
-    mocker: MockFixture,
-) -> None:
-    expected_values = [0x00AABBCC, 0x12345678, 0x9ABCDEF0]
+@pytest.fixture
+def mock_shell(mocker: MockFixture) -> Any:
     mock_shell = mocker.Mock()
-    mock_file = mocker.Mock()
-    mock_file.read.side_effect = expected_values
+    mock_shell.cmd.side_effect = help_message
+    return mock_shell
 
+
+@pytest.fixture
+def mock_file(mocker: MockFixture) -> Any:
+    mock_file = mocker.Mock()
+    mock_file.read.side_effect = lambda val: MEMORY_MAP[int(val)]
+    mock_file.write.side_effect = lambda val: MEMORY_MAP[int(val[0])]
+    return mock_file
+
+
+def test_help_command_output(capsys: CaptureFixture, mock_shell) -> None:
+    mock_shell.cmd.side_effect = help_message
+    mock_shell.cmd('help')
+    captured = capsys.readouterr()
+    assert all(
+        expected in captured.out
+        for expected in ['write', 'read', 'fullwrite', 'fullread', 'help']
+    )
+
+
+def test_read_commands(mock_shell, mock_file) -> None:
     mock_shell.cmd.side_effect = lambda cmd: mock_file.read(parse_read_command(cmd))
-    assert expected_values[0] == mock_shell.cmd('read 0')
-    assert expected_values[1] == mock_shell.cmd('read 1')
-    assert expected_values[2] == mock_shell.cmd('read 99')
+    for call in mock_file.read.call_args_list:
+        lba = call.args[0]
+        assert MEMORY_MAP[int(lba)]
 
 
-def test_read_command_rejects_invalid_inputs(mocker: MockFixture) -> None:
-    mock_shell = mocker.Mock()
-    mock_shell.cmd.side_effect = lambda cmd: parse_read_command(cmd)
-
-    with pytest.raises(ValueError, match='Invalid arguments. Usage: read <lba>'):
-        mock_shell.cmd('read')  # Missing arguments
-    with pytest.raises(ValueError, match='Invalid arguments. Usage: read <lba>'):
-        mock_shell.cmd('read -1')  # LBA out of range
-    with pytest.raises(ValueError, match='Invalid arguments. Usage: read <lba>'):
-        mock_shell.cmd('read 100')  # LBA out of range
-    with pytest.raises(ValueError, match='Invalid arguments. Usage: read <lba>'):
-        mock_shell.cmd('read abc')  # Invalid LBA format
+@pytest.mark.parametrize('command', ['read', 'read -1', 'read 100', 'read abc'])
+def test_invalid_read_commands(command: str) -> None:
+    with pytest.raises(ValueError, match=READ_HELP_MESSAGE):
+        parse_read_command(command)
 
 
-def test_write_command_returns_expected_values_for_valid_inputs(
-    mocker: MockFixture,
-) -> None:
-    expected_responses = {0: 0x00AABBCC, 1: 0x12345678, 99: 0x9ABCDEF0}
-    mock_shell = mocker.Mock()
-    mock_file = mocker.Mock()
-    mock_file.write.side_effect = lambda val: expected_responses[int(val[0])]
+@pytest.mark.parametrize(
+    'command',
+    [
+        'write 0 0xAABBCC',
+        'write 1 0x12345678',
+        'write 99 0x9ABCDEF0',
+    ],
+)
+def test_write_commands(command: str, mock_shell, mock_file) -> None:
     mock_shell.cmd.side_effect = lambda cmd: mock_file.write(parse_write_command(cmd))
-    mock_shell.cmd('write 0 0xAABBCC')
-    mock_shell.cmd('write 1 0x12345678')
-    mock_shell.cmd('write 99 0x9ABCDEF0')
     for call in mock_file.write.call_args_list:
+        mock_shell.cmd(command)
         lba, data = call.args[0]
-        assert expected_responses[int(lba)] == int(data, 16)
+        assert MEMORY_MAP[int(lba)] == int(data, 16)
 
 
-def test_write_command_rejects_invalid_inputs(mocker: MockFixture) -> None:
-    mock_shell = mocker.Mock()
-    mock_shell.cmd.side_effect = lambda cmd: parse_write_command(cmd)
-
-    with pytest.raises(
-        ValueError, match='Invalid arguments. Usage: write <lba> <hex data>'
-    ):
-        mock_shell.cmd('write')  # Missing arguments
-    with pytest.raises(
-        ValueError, match='Invalid arguments. Usage: write <lba> <hex data>'
-    ):
-        mock_shell.cmd('write 0')  # Missing data
-    with pytest.raises(
-        ValueError, match='Invalid arguments. Usage: write <lba> <hex data>'
-    ):
-        mock_shell.cmd('write -1 0x123')  # LBA out of range
-    with pytest.raises(
-        ValueError, match='Invalid arguments. Usage: write <lba> <hex data>'
-    ):
-        mock_shell.cmd('write 100 0x123')  # LBA out of range
-    with pytest.raises(
-        ValueError, match='Invalid arguments. Usage: write <lba> <hex data>'
-    ):
-        mock_shell.cmd('write abc 0x123')  # Invalid LBA format
-    with pytest.raises(
-        ValueError, match='Invalid arguments. Usage: write <lba> <hex data>'
-    ):
-        mock_shell.cmd('write 0 x123')  # Invalid data format
+@pytest.mark.parametrize(
+    'command',
+    [
+        'write',
+        'write 0',
+        'write -1 0x123',
+        'write 100 0x123',
+        'write abc 0x123',
+        'write 0 x123',
+    ],
+)
+def test_invalid_write_commands(command: str) -> None:
+    with pytest.raises(ValueError, match=WRITE_HELP_MESSAGE):
+        parse_write_command(command)


### PR DESCRIPTION
## 🏷️ PR Type
- [X] Feature
- [ ] Bugfix
- [X] Refactoring

## 🚀 Description
- Implemented unit test code for shell commands
- Includes 5 test cases: help, read (valid & invalid), write (valid & invalid)

## 📢 Notes (전달사항, Test 여부)
- Command parsing logic and some constants are temporary and will be removed once the shell is fully implemented
- All tests pass independently without relying on any other code
