### PR TITLE
Tests/shell/read

### DIFF
--- a/tests/shell/test_read.py
+++ b/tests/shell/test_read.py
@@ -3,15 +3,16 @@ from pytest_mock import MockerFixture
 
 from shell.shell import Shell
 
+SHELL_INPUT = 'builtins.input'
+
 
 def test_shell_read(capsys: pytest.CaptureFixture, mocker: MockerFixture):
     ssd = mocker.Mock()
-    ssd.read.side_effect = ['0x00000001']
+    ssd.read.return_value = '0x00000001'
 
-    mocker.patch('builtins.input', side_effect=['read 0', 'exit'])
+    mocker.patch(SHELL_INPUT, side_effect=['read 0', 'exit'])
 
-    shell = Shell()
-    shell.init(ssd)
+    shell = Shell(ssd)
     shell.run()
 
     captured = capsys.readouterr()
@@ -25,10 +26,9 @@ def test_shell_read(capsys: pytest.CaptureFixture, mocker: MockerFixture):
 def test_shell_read_invalid_input(capsys: pytest.CaptureFixture, mocker: MockerFixture):
     ssd = mocker.Mock()
 
-    mocker.patch('builtins.input', side_effect=['read 0 0 0', 'exit'])
+    mocker.patch(SHELL_INPUT, side_effect=['read 0 0 0', 'exit'])
 
-    shell = Shell()
-    shell.init(ssd)
+    shell = Shell(ssd)
     shell.run()
 
     captured = capsys.readouterr()
@@ -41,10 +41,9 @@ def test_shell_read_exception(capsys: pytest.CaptureFixture, mocker: MockerFixtu
     ssd = mocker.Mock()
     ssd.read.side_effect = [ValueError]
 
-    mocker.patch('builtins.input', side_effect=['read 0', 'exit'])
+    mocker.patch(SHELL_INPUT, side_effect=['read 0', 'exit'])
 
-    shell = Shell()
-    shell.init(ssd)
+    shell = Shell(ssd)
     shell.run()
 
     captured = capsys.readouterr()


### PR DESCRIPTION
## 🏷️ PR Type
- [x] Feature
- [ ] Bugfix
- [x] Refactoring

## 📌 Related Issue
- Shell Command 중 "Read" 명령 수행 테스트

## 🚀 Description
- Shell 생성자에 SSD 객체를 mock 으로 생성하여 주입했습니다.
- Shell에서 Read 명령이 수행될 수 있도록 input을 patch하였습니다.
- Shell Read 명령 수행 후 Exit 명령 수행하도록 다음 명령어로 실행했습니다.
- Shell에서 SSD의 Read 정상 print 값, Error 출력 테스트 추가하였습니다.


### [Ground Rule](https://github.com/hobism3/SSD_A-Teuk/issues/20)
### [Code Review 전략](https://github.com/hobism3/SSD_A-Teuk/issues/1)
