### PR TITLE
test_ssd 리팩토링

### DIFF
--- a/ssd.py
+++ b/ssd.py
@@ -53,8 +53,8 @@ class SSD:
         if not self.validate_address(line_number):
             self.report_error()
             return
-        ret_value = ""
-        with open(SSD_NAND_FILE_PATH, 'r') as f:
+        ret_value = ''
+        with open(SSD_NAND_FILE_PATH) as f:
             for line in f:
                 data = line.strip().split(' ')
                 ind = int(data[0])
@@ -89,6 +89,9 @@ class SSD:
             self.initialize_ssd_output()
         except InvalidInputError:
             self.report_error()
+
+    def execute(self, param, param1, param2=None):
+        pass
 
 
 def main():

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -68,7 +68,7 @@ def test_ssd_initial_nand_value_check(ssd):
 
 def test_ssd_write_pass(ssd, sample_input_address):
     input_address, input_value = sample_input_address
-    ssd.write(input_address, input_value)
+    ssd.execute('W', input_address, input_value)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert not actual_value
@@ -76,7 +76,7 @@ def test_ssd_write_pass(ssd, sample_input_address):
 
 def test_ssd_write_pas_scheck_value(ssd, sample_input_address):
     input_address, input_value = sample_input_address
-    ssd.write(input_address, input_value)
+    ssd.execute('W', input_address, input_value)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert not actual_value
@@ -87,28 +87,28 @@ def test_ssd_write_pas_scheck_value(ssd, sample_input_address):
 
 def test_ssd_write_fail_wrong_address(ssd, sample_input_address_wrong):
     input_address, input_value = sample_input_address_wrong
-    ssd.write(input_address, input_value)
+    ssd.execute('W', input_address, input_value)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]
 
 
 def test_ssd_write_fail_no_value(ssd):
-    ssd.write(VALID_ADDRESS, None)
+    ssd.execute('W', VALID_ADDRESS, None)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]
 
 
 def test_ssd_write_fail_no_address(ssd):
-    ssd.write(None, VALID_VALUE)
+    ssd.execute('W', None, VALID_VALUE)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]
 
 
 def test_ssd_write_fail_no_both(ssd):
-    ssd.write(None, None)
+    ssd.execute('W', None, None)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]
@@ -116,7 +116,7 @@ def test_ssd_write_fail_no_both(ssd):
 
 def test_ssd_write_fail_wrong_value(ssd, sample_input_value_wrong):
     input_address, input_value = sample_input_value_wrong
-    ssd.write(input_address, input_value)
+    ssd.execute('W', input_address, input_value)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]
@@ -168,7 +168,7 @@ def test_ssd_write_fail_w_command_no_both(ssd):
 
 def test_ssd_read_initial_value_check(ssd, sample_input_address_w_initial_value):
     input_address, expected_value = sample_input_address_w_initial_value
-    ssd.read(input_address)
+    ssd.execute('R', input_address)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [expected_value]
@@ -177,15 +177,15 @@ def test_ssd_read_initial_value_check(ssd, sample_input_address_w_initial_value)
 def test_ssd_read_written_value_pass(ssd, sample_input_address):
     input_address, input_value = sample_input_address
 
-    ssd.write(input_address, input_value)
-    ssd.read(input_address)
+    ssd.execute('W', input_address, input_value)
+    ssd.execute('R', input_address)
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
 
     assert actual_value == [input_value]
 
 
 def test_ssd_read_fail_wrong_address(ssd, sample_input_address_wrong):
-    ssd.read(sample_input_address_wrong[0])
+    ssd.execute('R', sample_input_address_wrong[0])
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]


### PR DESCRIPTION
## 🏷️ PR Type
- [x] Feature
- [ ] Bugfix
- [x] Refactoring

## 📌 Related Issue
- 

## 🚀 Description
- 전반적으로 쭉 테스트 코드 리팩토링해봤습니다.
- `read`, 'write' 를 'execute'로 전환하였습니다. 

## 📢 Notes (전달사항, Test 여부)
- 여기서 fail 나는 경우는 
```FAILED [ 36%]
tests\test_ssd.py:116 (test_ssd_write_fail_wrong_value[sample_input_value_wrong1])
[] != ['ERROR']

Expected :['ERROR']
Actual   :[]
<Click to see difference>

ssd = <ssd.SSD object at 0x0000020209078250>
sample_input_value_wrong = ('00', '0xFFFF')
```
이런식으로 인풋 value 가 `0xFFFF` 처럼 길이가 10개가 되지 않았지만, 숫자 표현이 되어서 난 경우입니다. 
<img width="830" height="684" alt="image" src="https://github.com/user-attachments/assets/1ac310c9-5997-4a1c-848e-43db3dee68fb" />



### [Ground Rule](https://github.com/hobism3/SSD_A-Teuk/issues/20)
### [Code Review 전략](https://github.com/hobism3/SSD_A-Teuk/issues/1)
