### PR TITLE
feat: Connect ssd and buffer

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -36,7 +36,7 @@ class Buffer:
             self.logger.error(f'Creation of the directory {dir} failed')
 
     def buffer_file_read_as_list(self) -> list:
-        list = [file.split('_')[1:] for file in sorted(os.listdir('buffer'))]
+        list = [file.split('_')[1:] for file in sorted(os.listdir(BUFFER_DIR))]
         for i in range(len(list)):
             if list[i][0] == 'empty':
                 continue
@@ -47,7 +47,7 @@ class Buffer:
         return list
 
     def buffer_file_read(self) -> list:
-        return sorted(os.listdir('buffer'))
+        return sorted(os.listdir(BUFFER_DIR))
 
     def buffer_file_write(self):
         file_list = self.buffer_file_read()

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -37,6 +37,7 @@ def ssd():
     ssd = SSD()
     ssd.initialize_ssd_nand()
     ssd.initialize_ssd_output()
+    ssd.buffer.buffer_clear()
     return ssd
 
 
@@ -86,6 +87,7 @@ def test_ssd_invalid_mode_w_command(ssd, runner_factory):
 def test_ssd_write_pass(ssd, runner_factory, valid_address):
     runner = runner_factory(ssd)
     runner('W', valid_address, VALID_VALUE)
+    ssd._flush()
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert not actual_value


### PR DESCRIPTION
## 🏷️ PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring

## 📌 Related Issue
- 

## 🚀 Description
- ssd의 command로 buffer 기능 사용하게끔 연결하였습니다.
- read의 경우 기존의 read에서 buffer read 후 그 결과로 ssd read를 진행할지 결정합니다.

## 📢 Notes (전달사항, Test 여부)
- 기존 write test가 ssd_nand.txt를 참조하고 있어 test 후 항상 flush 하도록 임의 수정하였으니 확인 부탁드립니다.


### [Ground Rule](https://github.com/hobism3/SSD_A-Teuk/issues/20)
### [Code Review 전략](https://github.com/hobism3/SSD_A-Teuk/issues/1)
