### PR TITLE
SSD test 시 buffer mock 사용 및 cli 별도 테스트 분리

### DIFF
--- a/tests/test_ssd/test_erase.py
+++ b/tests/test_ssd/test_erase.py
@@ -1,58 +1,45 @@
+from unittest.mock import patch
+
 import pytest
 
 from tests.test_ssd.conftest import (
     ERROR,
-    INITIAL_VALUE,
-    SSD_NAND_FILE_PATH,
     SSD_OUTPUT_FILE_PATH,
     VALID_ADDRESS,
     VALID_SIZE,
     read_file_with_lines,
-    run_cli,
     run_direct,
 )
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
-def test_ssd_erase_pass(ssd, runner_factory, valid_address):
+@pytest.mark.parametrize('runner_factory', [run_direct])
+@patch('ssd_tool.buffer.Buffer.buffer_arrange')
+@patch('ssd_tool.buffer.Buffer.buffer_file_write')
+def test_ssd_erase_pass(
+    mock_buffer_file_write, mock_buffer_arrange, ssd, runner_factory, valid_address
+):
     runner = runner_factory(ssd)
     for valid_size in range(1, 10):
         if valid_address == '99':
             continue
         runner('E', valid_address, str(valid_size))
+        assert mock_buffer_arrange.called
+
         actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
         assert not actual_value
 
-        actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
-        assert (
-            actual_value[int(valid_address)]
-            == f'{int(valid_address):02d} {INITIAL_VALUE}'
-        )
 
-
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 def test_ssd_erase_over_size(ssd, runner_factory, valid_address):
     runner = runner_factory(ssd)
     for valid_size in range(1, 10):
-        if valid_address != '99':
-            continue
-        if valid_size == 1:
-            runner('E', valid_address, str(valid_size))
-            actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
-            assert not actual_value
-
-            actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
-            assert (
-                actual_value[int(valid_address)]
-                == f'{int(valid_address):02d} {INITIAL_VALUE}'
-            )
-        else:
+        if int(valid_address) + valid_size > 100:
             runner('E', valid_address, str(valid_size))
             actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
             assert actual_value == [ERROR]
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 def test_ssd_erase_fail_not_invalid_size(ssd, runner_factory, invalid_size):
     runner = runner_factory(ssd)
     runner('E', VALID_ADDRESS, invalid_size)
@@ -64,10 +51,9 @@ def test_ssd_erase_fail_not_invalid_size(ssd, runner_factory, invalid_size):
 @pytest.mark.parametrize(
     'address, size', [(None, VALID_SIZE), (VALID_ADDRESS, None), (None, None)]
 )
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 def test_ssd_erase_fail_not_enough_args(ssd, runner_factory, address, size):
     runner = runner_factory(ssd)
     runner('E', address, size)
-
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]

--- a/tests/test_ssd/test_flush.py
+++ b/tests/test_ssd/test_flush.py
@@ -3,60 +3,55 @@ from unittest.mock import patch
 import pytest
 
 from tests.test_ssd.conftest import (
-    INITIAL_VALUE,
-    SSD_NAND_FILE_PATH,
-    SSD_OUTPUT_FILE_PATH,
-    VALID_VALUE,
-    read_buffer,
-    read_file_with_lines,
-    run_cli_wo_flush,
     run_direct_wo_flush,
 )
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct_wo_flush, run_cli_wo_flush])
-def test_ssd_flush_pass(ssd, runner_factory):
+@pytest.mark.parametrize('runner_factory', [run_direct_wo_flush])
+@pytest.mark.parametrize(
+    'mock_return',
+    [
+        [['empty'], ['empty'], ['empty'], ['empty'], ['empty']],
+        [['E', 3, 3], ['E', 9, 3], ['empty'], ['empty'], ['empty']],
+        [['W', 2, '0x00000001'], ['empty'], ['empty'], ['empty'], ['empty']],
+    ],
+)
+@patch('ssd_tool.buffer.Buffer.buffer_file_read_as_list')
+def test_ssd_flush_pass(
+    mock_buffer_file_read_as_list, mock_return, ssd, runner_factory
+):
     runner = runner_factory(ssd)
+    mock_buffer_file_read_as_list.return_value = mock_return
     runner('F')
+    with (
+        patch.object(ssd, '_write', autospec=True) as mock_write,
+        patch.object(ssd, '_erase', autospec=True) as mock_erase,
+        patch.object(ssd._buffer, 'buffer_clear', autospec=True) as mock_clear,
+    ):
+        runner('F')
 
-    actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
-    assert not actual_value
-
-    actual_value = read_buffer()
-    assert 'empty' not in actual_value
+        assert mock_write.call_count == sum(1 for b in mock_return if b[0] == 'W')
+        assert mock_erase.call_count == sum(1 for b in mock_return if b[0] == 'E')
+        mock_clear.assert_called_once()
 
 
 @pytest.mark.parametrize('runner_factory', [run_direct_wo_flush])
-def test_ssd_auto_flush_operation_with_direct(ssd, runner_factory):
+@pytest.mark.parametrize(
+    'mock_return',
+    [
+        [['E', 1, 1], ['E', 3, 1], ['E', 5, 1], ['E', 7, 1], ['E', 9, 1]],
+        [['E', 1, 1], ['E', 3, 1], ['E', 5, 1], ['E', 7, 1], ['empty']],
+    ],
+)
+@patch('ssd_tool.buffer.Buffer.buffer_file_read_as_list')
+def test_ssd_auto_flush_operation_with_direct(
+    mock_buffer_file_read_as_list, mock_return, ssd, runner_factory
+):
     runner = runner_factory(ssd)
-    with patch('ssd.SSD.flush') as mock_flush:
-        for i in range(5):
-            runner('W', str(i), VALID_VALUE)
-
-        mock_flush.assert_not_called()
+    mock_buffer_file_read_as_list.return_value = mock_return
+    with patch.object(ssd, 'flush', autospec=True) as mock_flush:
         runner('R', '0')
-        mock_flush.assert_called_once()
-
-        mock_flush.reset_mock()
-        actual_value = read_buffer()
-        assert 'empty' not in actual_value
-
-
-@pytest.mark.parametrize('runner_factory', [run_cli_wo_flush])
-def test_ssd_auto_flush_operation_with_cli(ssd, runner_factory):
-    runner = runner_factory(ssd)
-    for i in range(5):
-        runner('W', str(i), VALID_VALUE)
-
-    actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
-    for i in range(5):
-        assert actual_value[int(i)] == f'{int(i):02d} {INITIAL_VALUE}'
-
-    runner('W', '0', str(int(VALID_VALUE, 16) + 0x00000001))
-
-    actual_value = read_buffer()
-    assert 'empty' not in actual_value
-
-    actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
-    for i in range(5):
-        assert actual_value[int(i)] == f'{int(i):02d} {VALID_VALUE}'
+        if ssd._buffer.buffer_length == 5:
+            mock_flush.assert_called_once()
+        else:
+            mock_flush.assert_not_called()

--- a/tests/test_ssd/test_read.py
+++ b/tests/test_ssd/test_read.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from tests.test_ssd.conftest import (
@@ -6,21 +8,25 @@ from tests.test_ssd.conftest import (
     SSD_OUTPUT_FILE_PATH,
     VALID_VALUE,
     read_file_with_lines,
-    run_cli,
     run_direct,
 )
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
-def test_ssd_read_initial_value_check(ssd, runner_factory, valid_address):
+@pytest.mark.parametrize('runner_factory', [run_direct])
+@pytest.mark.parametrize('mock_return', [(False, '')])
+@patch('ssd_tool.buffer.Buffer.read')
+def test_ssd_read_initial_value_check(
+    mock_read, mock_return, ssd, runner_factory, valid_address
+):
     runner = runner_factory(ssd)
+    mock_read.return_value = mock_return
     runner('R', valid_address)
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [INITIAL_VALUE]
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 def test_ssd_read_fail_wrong_address(ssd, runner_factory, invalid_address):
     runner = runner_factory(ssd)
     runner('R', invalid_address)
@@ -29,14 +35,14 @@ def test_ssd_read_fail_wrong_address(ssd, runner_factory, invalid_address):
     assert actual_value == [ERROR]
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
-def test_ssd_read_written_value_pass(ssd, runner_factory, valid_address):
+@pytest.mark.parametrize('runner_factory', [run_direct])
+@pytest.mark.parametrize('mock_return', [(True, VALID_VALUE)])
+@patch('ssd_tool.buffer.Buffer.read')
+def test_ssd_read_written_value_pass(
+    mock_read, mock_return, ssd, runner_factory, valid_address
+):
     runner = runner_factory(ssd)
-
-    runner('W', valid_address, VALID_VALUE)
-    actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
-    assert not actual_value
-
+    mock_read.return_value = mock_return
     runner('R', valid_address)
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [VALID_VALUE]

--- a/tests/test_ssd/test_ssd_general.py
+++ b/tests/test_ssd/test_ssd_general.py
@@ -1,3 +1,6 @@
+import sys
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from tests.test_ssd.conftest import (
@@ -7,8 +10,10 @@ from tests.test_ssd.conftest import (
     SSD_OUTPUT_FILE_PATH,
     VALID_ADDRESS,
     VALID_VALUE,
+    read_buffer,
     read_file_with_lines,
     run_cli,
+    run_cli_wo_flush,
     run_direct,
 )
 
@@ -26,3 +31,44 @@ def test_ssd_invalid_mode_w_command(ssd, runner_factory):
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert actual_value == [ERROR]
+
+
+@pytest.mark.parametrize('runner_factory', [run_cli_wo_flush])
+def test_ssd_auto_flush_operation_with_cli(ssd, runner_factory):
+    runner = runner_factory(ssd)
+    for i in range(5):
+        runner('W', str(i), VALID_VALUE)
+
+    actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
+    for i in range(5):
+        assert actual_value[int(i)] == f'{int(i):02d} {INITIAL_VALUE}'
+
+    runner('W', '0', str(int(VALID_VALUE, 16) + 0x00000001))
+
+    actual_value = read_buffer()
+    assert 'empty' not in actual_value
+
+    actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
+    for i in range(5):
+        assert actual_value[int(i)] == f'{int(i):02d} {VALID_VALUE}'
+
+
+@pytest.mark.parametrize('runner_factory', [run_cli])
+@pytest.mark.parametrize('command', ['W', 'R', 'E', 'F'])
+@patch('ssd.CommandFactory')
+def test_ssd_read_initial_value_check(
+    mock_command_factory, ssd, command, runner_factory
+):
+    mock_command = MagicMock()
+    mock_command_factory.create_command.return_value = mock_command
+    import ssd
+
+    args = {
+        'W': ['W', '2', '0x00000001'],
+        'R': ['R', '2'],
+        'E': ['E', '2', '2'],
+        'F': ['F'],
+    }
+    sys.argv = args[command]
+    ssd.main()
+    mock_command.execute.assert_called_once()

--- a/tests/test_ssd/test_write.py
+++ b/tests/test_ssd/test_write.py
@@ -1,30 +1,32 @@
+from unittest.mock import patch
+
 import pytest
 
 from tests.test_ssd.conftest import (
     ERROR,
-    SSD_NAND_FILE_PATH,
     SSD_OUTPUT_FILE_PATH,
     VALID_ADDRESS,
     VALID_VALUE,
     read_file_with_lines,
-    run_cli,
     run_direct,
 )
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
-def test_ssd_write_pass(ssd, runner_factory, valid_address):
+@pytest.mark.parametrize('runner_factory', [run_direct])
+@patch('ssd_tool.buffer.Buffer.buffer_arrange')
+@patch('ssd_tool.buffer.Buffer.buffer_file_write')
+def test_ssd_write_pass(
+    mock_buffer_file_write, mock_buffer_arrange, ssd, runner_factory, valid_address
+):
     runner = runner_factory(ssd)
     runner('W', valid_address, VALID_VALUE)
+    assert mock_buffer_arrange.called
 
     actual_value = read_file_with_lines(SSD_OUTPUT_FILE_PATH)
     assert not actual_value
 
-    actual_value = read_file_with_lines(SSD_NAND_FILE_PATH)
-    assert actual_value[int(valid_address)] == f'{int(valid_address):02d} {VALID_VALUE}'
 
-
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 @pytest.mark.parametrize(
     'address, value', [(None, VALID_VALUE), (VALID_ADDRESS, None), (None, None)]
 )
@@ -36,7 +38,7 @@ def test_ssd_write_fail_not_enough_args(ssd, runner_factory, address, value):
     assert actual_value == [ERROR]
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 def test_ssd_write_fail_wrong_value(ssd, runner_factory, invalid_value):
     runner = runner_factory(ssd)
     runner('W', VALID_ADDRESS, invalid_value)
@@ -45,7 +47,7 @@ def test_ssd_write_fail_wrong_value(ssd, runner_factory, invalid_value):
     assert actual_value == [ERROR]
 
 
-@pytest.mark.parametrize('runner_factory', [run_direct, run_cli])
+@pytest.mark.parametrize('runner_factory', [run_direct])
 def test_ssd_write_fail_wrong_address(ssd, runner_factory, invalid_address):
     runner = runner_factory(ssd)
     runner('W', invalid_address, VALID_VALUE)


### PR DESCRIPTION
## 🏷️ PR Type
- [ ] Feature
- [ ] Bugfix
- [x] Refactoring

## 📌 Related Issue
- 

## 🚀 Description
- CLI 테스트가 시간을 많이 차지하여 execute call에 대한 검증만 따로 진행
- 실제 method들은 method test로 검증
- buffer 사용은 시간을 많이 차지하여 buffer mock으로 대체

## 📢 Notes (전달사항, Test 여부)
- 


### [Ground Rule](https://github.com/hobism3/SSD_A-Teuk/issues/20)
### [Code Review 전략](https://github.com/hobism3/SSD_A-Teuk/issues/1)
